### PR TITLE
Initial CSM SET

### DIFF
--- a/src/Set.cpp
+++ b/src/Set.cpp
@@ -1,8 +1,16 @@
 #include <iostream>
 
+#include "SensorUtils.h"
+
 using namespace std;
 
 int main() {
-   cout << "Hello World!" << endl;
-   return 0;
+  // Calculate the phase angle
+  std::vector<double> lookDir = {0.0, 0.0, 0.0};
+  std::vector<double> sunPosition = {0.0, 0.0, 0.0};
+  
+  double phaseAngle = PhaseAngle(lookDir, sunPosition); 
+  std::cout << "Phase Angle: " << phaseAngle << std::endl; 
+
+  return 0;
 }

--- a/src/Set.cpp
+++ b/src/Set.cpp
@@ -1,10 +1,31 @@
 #include <iostream>
+#include <fstream>
 
+#include "UsgsAstroFramePlugin.h"
+#include "UsgsAstroFrameSensorModel.h"
 #include "SensorUtils.h"
+
+#include <json/json.hpp>
+using json = nlohmann::json;
 
 using namespace std;
 
 int main() {
+  // Load ISD file
+  csm::Isd imageSupportData("simpleFramerISD.json");
+  imageSupportData.clearAllParams();
+
+  std::ifstream isdFile("simpleFramerISD.json");
+  json jsonIsd = json::parse(isdFile);
+
+  for (json::iterator it = jsonIsd.begin(); it != jsonIsd.end(); ++it) {
+    imageSupportData.addParam(it.key(), it.value().dump());
+  }
+  isdFile.close(); 
+  
+  // Check that csm::Isd was populated correctly: 
+  std::cout << "Focal length value: " << imageSupportData.param("focal_length") << std::endl;
+
   // Calculate the phase angle
   std::vector<double> lookDir = {0.0, 0.0, 0.0};
   std::vector<double> sunPosition = {0.0, 0.0, 0.0};

--- a/src/Set.cpp
+++ b/src/Set.cpp
@@ -5,6 +5,8 @@
 #include "UsgsAstroFrameSensorModel.h"
 #include "SensorUtils.h"
 
+#include <sstream>
+#include <string>
 #include <json/json.hpp>
 using json = nlohmann::json;
 
@@ -19,18 +21,37 @@ int main() {
   json jsonIsd = json::parse(isdFile);
 
   for (json::iterator it = jsonIsd.begin(); it != jsonIsd.end(); ++it) {
-    imageSupportData.addParam(it.key(), it.value().dump());
+    if (it.value().size() >1 ) {
+      vector<double> v = it.value();
+      for (int j=0;j < v.size(); j++) {
+        ostringstream val;
+        val << setprecision(15) << v[j];
+        imageSupportData.addParam(it.key(),val.str());
+      }
+    }
+    else {
+      imageSupportData.addParam(it.key(), it.value().dump());
+    }
   }
   isdFile.close(); 
-  
-  // Check that csm::Isd was populated correctly: 
-  std::cout << "Focal length value: " << imageSupportData.param("focal_length") << std::endl;
+
+  // Instantiate a Camera Model 
+  csm::WarningList *warnings;
+  UsgsAstroFramePlugin framePlugin;
+  csm::Model *cameraModel = framePlugin.constructModelFromISD(imageSupportData,
+                                                             "USGS_ASTRO_FRAME_SENSOR_MODEL",
+                                                              warnings);
+  // Grab the Camera Model model state to get the sun location
+  std::string modelState = cameraModel->getModelState(); 
+  json parsedIsd = json::parse(modelState);
+
+  // TODO: actually use the values from the CSM camera model for the phase angle calculation
 
   // Calculate the phase angle
   std::vector<double> lookDir = {0.0, 0.0, 0.0};
   std::vector<double> sunPosition = {0.0, 0.0, 0.0};
   
-  double phaseAngle = PhaseAngle(lookDir, sunPosition); 
+  double phaseAngle = PhaseAngle(lookDir, sunPosition);
   std::cout << "Phase Angle: " << phaseAngle << std::endl; 
 
   return 0;


### PR DESCRIPTION
This initial draft of a CSM SET does the following:

* reads an ISD into a csm::Isd object
* successfully instantiates a camera model using this ISD
* calls PhaseAngle from SensorUtils with two vectors full of zeroes
* prints this PhaseAngle output to the screen

We were unable to figure out how to get the look vector and the sun position out of the CSM Camera Model today, but this could still be merged as a functional application that outputs: 

```
PhaseAngle: 0
```

and demonstrates that the csm, CSM Camera Model, and SensorUtils code can work together, even though not all the pieces are yet hooked up. 

